### PR TITLE
Feature/skip

### DIFF
--- a/RogueSound.Functions/ClearQueueFunction.cs
+++ b/RogueSound.Functions/ClearQueueFunction.cs
@@ -17,7 +17,7 @@ namespace RogueSound.Functions
     public static partial class RogueSoundFunctions
     {
         [FunctionName("ClearQueue")]
-        public static async Task<IActionResult> ClearQueueFunction(
+        public static async Task<IActionResult> ClearQueue(
             [HttpTrigger(AuthorizationLevel.Anonymous, "delete", Route = null)] HttpRequest req,
             ILogger log)
         {

--- a/RogueSound.Functions/Extensions/SongQueueExtensions.cs
+++ b/RogueSound.Functions/Extensions/SongQueueExtensions.cs
@@ -26,6 +26,14 @@ namespace RogueSound.Functions
                 .FixQueueSongGapTimings(theOddOneOut);
         }
 
+        public static IEnumerable<SongQueueModel> RemoveCurrent(this IEnumerable<SongQueueModel> songQueue)
+        {
+            var theOddOneOut = songQueue.Where(x => x.StartTime < DateTime.Now && x.EndTime > DateTime.UtcNow).FirstOrDefault();
+
+            return songQueue.Except(new List<SongQueueModel>() { theOddOneOut })
+                .FixQueueSongGapTimings(theOddOneOut);
+        }
+
         public static IEnumerable<SongQueueModel> FixQueueSongGapTimings(this IEnumerable<SongQueueModel> songQueue, SongQueueModel gappedSong)
         {
             var gapSpan = TimeSpan.FromMilliseconds(gappedSong.Duration);

--- a/RogueSound.Functions/Extensions/SongQueueExtensions.cs
+++ b/RogueSound.Functions/Extensions/SongQueueExtensions.cs
@@ -50,7 +50,8 @@ namespace RogueSound.Functions
                 RoomId = x.RoomId,
                 SongId = x.SongId,
                 StartTime = x.StartTime.Subtract(gapSpan),
-                Title = x.Title
+                Title = x.Title,
+                PublicId = x.PublicId
             });
         }
     }

--- a/RogueSound.Functions/Extensions/SongQueueExtensions.cs
+++ b/RogueSound.Functions/Extensions/SongQueueExtensions.cs
@@ -28,10 +28,10 @@ namespace RogueSound.Functions
 
         public static IEnumerable<SongQueueModel> RemoveCurrent(this IEnumerable<SongQueueModel> songQueue)
         {
-            var theOddOneOut = songQueue.Where(x => x.StartTime < DateTime.Now && x.EndTime > DateTime.UtcNow).FirstOrDefault();
+            var playingSong = songQueue.Where(x => x.StartTime < DateTime.Now && x.EndTime > DateTime.UtcNow).FirstOrDefault();
 
-            return songQueue.Except(new List<SongQueueModel>() { theOddOneOut })
-                .FixQueueSongGapTimings(theOddOneOut);
+            return songQueue.Except(new List<SongQueueModel>() { playingSong })
+                .FixQueueSongGapTimings(playingSong);
         }
 
         public static IEnumerable<SongQueueModel> FixQueueSongGapTimings(this IEnumerable<SongQueueModel> songQueue, SongQueueModel gappedSong)

--- a/RogueSound.Functions/GetUpdatesFunction.cs
+++ b/RogueSound.Functions/GetUpdatesFunction.cs
@@ -17,7 +17,7 @@ namespace RogueSound.Functions
     public static partial class RogueSoundFunctions
     {
         [FunctionName("GetUpdates")]
-        public static async Task<IActionResult> GetUpdatesFunction(
+        public static async Task<IActionResult> GetUpdates(
             [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = null)] HttpRequest req,
             ILogger log)
         {

--- a/RogueSound.Functions/Model/SkipSongRequestModel.cs
+++ b/RogueSound.Functions/Model/SkipSongRequestModel.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace RogueSound.Functions
+{
+    public class SkipSongRequestModel
+    {
+        // public string CurrentSongId { get; set; }
+        
+        public string User { get; set; }
+    }
+}

--- a/RogueSound.Functions/Model/SkipSongRequestModel.cs
+++ b/RogueSound.Functions/Model/SkipSongRequestModel.cs
@@ -6,8 +6,6 @@ namespace RogueSound.Functions
 {
     public class SkipSongRequestModel
     {
-        // public string CurrentSongId { get; set; }
-        
-        public string User { get; set; }
+        public string RoomSessionId { get; set; }
     }
 }

--- a/RogueSound.Functions/SkipCurrentSongFunction.cs
+++ b/RogueSound.Functions/SkipCurrentSongFunction.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using Microsoft.Azure.Documents.Client;
+using System.Linq;
+using Microsoft.Azure.Documents.Linq;
+using Microsoft.Azure.Documents;
+using System.Collections.Generic;
+
+namespace RogueSound.Functions
+{
+    public static partial class RogueSoundFunctions
+    {
+        [FunctionName("SkipCurrentSong")]
+        public static async Task<IActionResult> SkipCurrentSong(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = null)] HttpRequest req,
+            ILogger log)
+        {
+            var data = JsonConvert.DeserializeObject<SkipSongRequestModel>(await req.ReadAsStringAsync());
+            log.LogInformation($"HttpTriger, skipping song as requested by {data.User}");
+
+            var queryUri = UriFactory.CreateDocumentCollectionUri("RogueSound", "Sessions");
+            var feedOptions = new FeedOptions { PartitionKey = new PartitionKey(0) };
+
+            var todayDate = DateTime.SpecifyKind(DateTime.Today, DateTimeKind.Utc);
+
+            var currentSessionQuery = client.CreateDocumentQuery<RoomSessionModel>(queryUri, feedOptions)
+                .Where(x => x.SessionDate == todayDate)
+                .OrderBy(x => x.CreatedAt)
+                .Take(1)
+                .AsDocumentQuery();
+
+            var sessionsReturned = new List<RoomSessionModel>();
+
+            while (currentSessionQuery.HasMoreResults) sessionsReturned.AddRange(await currentSessionQuery.ExecuteNextAsync<RoomSessionModel>());
+
+            var currentSession = sessionsReturned.FirstOrDefault();
+
+            log.LogInformation($"Returned {sessionsReturned.Count} sessions");
+
+            var songList = currentSession.Songs.ToList();
+
+            if (songList.Where(x => x.StartTime < DateTime.Now).Any())
+            {
+                currentSession.Songs = songList.RemoveCurrent();
+
+                var uri = UriFactory.CreateDocumentUri("RogueSound", "Sessions", currentSession.id);
+
+                var partitionOptions = new RequestOptions { PartitionKey = new PartitionKey(0) };
+
+                await client.ReplaceDocumentAsync(queryUri, currentSession, partitionOptions);
+            }
+
+            return new OkResult();
+        }
+    }
+}

--- a/RogueSound.Functions/SkipCurrentSongFunction.cs
+++ b/RogueSound.Functions/SkipCurrentSongFunction.cs
@@ -22,7 +22,7 @@ namespace RogueSound.Functions
             ILogger log)
         {
             var data = JsonConvert.DeserializeObject<SkipSongRequestModel>(await req.ReadAsStringAsync());
-            log.LogInformation($"HttpTriger, skipping song as requested by {data.User}");
+            log.LogInformation($"HttpTriger, skipping song in session {data.RoomSessionId})");
 
             var queryUri = UriFactory.CreateDocumentCollectionUri("RogueSound", "Sessions");
             var feedOptions = new FeedOptions { PartitionKey = new PartitionKey(0) };
@@ -35,7 +35,7 @@ namespace RogueSound.Functions
                 .Take(1)
                 .AsDocumentQuery();
 
-            var sessionsReturned = new List<RoomSessionModel>();
+            var sessionsReturned = new List<RoomSessionModel>();    
 
             while (currentSessionQuery.HasMoreResults) sessionsReturned.AddRange(await currentSessionQuery.ExecuteNextAsync<RoomSessionModel>());
 
@@ -53,7 +53,7 @@ namespace RogueSound.Functions
 
                 var partitionOptions = new RequestOptions { PartitionKey = new PartitionKey(0) };
 
-                await client.ReplaceDocumentAsync(queryUri, currentSession, partitionOptions);
+                await client.ReplaceDocumentAsync(uri, currentSession, partitionOptions);
             }
 
             return new OkResult();


### PR DESCRIPTION
**Changes**

- Adds RemoveCurrent SongQueue extension. Which returns list minus the current song with adjusted timings.
- Adds SkipCurrenSong function (endpoint + logic). Updates CosmosDB document for the current session by removing the current playing song if there is any and adjusts the timings.

**Feature Usage**
Param RoomSessionId is required.

POST functions_endpoint/api/SkipCurrentSong 
{
    "RoomSessionId": "0"
}

**Considerations**

- Partition key for Sessions is the room id. Until further notice partition key for queries is set to 0.
- FE does not update current playing song with the dump polling, refreshing is required until FE implements a current song checkup.
